### PR TITLE
Asset browser improvements (#9 + 1 more)

### DIFF
--- a/VTTiny/Assets/Asset.cs
+++ b/VTTiny/Assets/Asset.cs
@@ -28,6 +28,8 @@ namespace VTTiny.Assets
         /// </summary>
         public AssetDatabase Database { get; set; }
 
+        public const int ASSET_PREVIEW_SIZE = 100;
+
         /// <summary>
         /// Constructs a reference to this asset.
         /// </summary>

--- a/VTTiny/Assets/Texture.cs
+++ b/VTTiny/Assets/Texture.cs
@@ -125,7 +125,7 @@ namespace VTTiny.Assets
 
         public override void RenderAssetPreview()
         {
-            EditorGUI.ImageButton(this, 100, 100);
+            EditorGUI.ImageButton(this, ASSET_PREVIEW_SIZE, ASSET_PREVIEW_SIZE);
         }
 
         protected override void InternalRenderEditorGUI()

--- a/VTTiny/Editor/UI/Windows/AssetBrowserWindow.cs
+++ b/VTTiny/Editor/UI/Windows/AssetBrowserWindow.cs
@@ -35,10 +35,13 @@ namespace VTTiny.Editor.UI
             if (!Raylib.IsFileDropped() || !ImGui.IsWindowHovered())
                 return;
 
-            var path = Raylib.GetDroppedFiles()[0];
+            var paths = Raylib.GetDroppedFiles();
             Raylib.ClearDroppedFiles();
 
-            AssetHelper.LoadBasedOnExtension(path, Stage.AssetDatabase);
+            foreach (var path in paths)
+            {
+                AssetHelper.LoadBasedOnExtension(path, Stage.AssetDatabase);
+            }
         }
 
         /// <summary>
@@ -62,8 +65,19 @@ namespace VTTiny.Editor.UI
             }
             else
             {
+                var style = ImGui.GetStyle();
+
+                var contentRegion = ImGui.GetContentRegionAvail().X + style.WindowPadding.X;
+                var assetPreviewMargins = style.CellPadding.X + (style.FramePadding.X * 2);
+
+                var maxItems = (int)System.MathF.Max(1, contentRegion / (Asset.ASSET_PREVIEW_SIZE + assetPreviewMargins));
+
+                var currentItems = 0;
+
                 foreach (var asset in Stage.AssetDatabase.GetAssets())
                 {
+                    currentItems++;
+
                     asset.RenderAssetPreview();
 
                     if (ImGui.IsItemClicked())
@@ -71,7 +85,10 @@ namespace VTTiny.Editor.UI
 
                     Editor.DoContextMenuFor(asset);
 
-                    ImGui.SameLine();
+                    if (currentItems % maxItems != 0)
+                    {
+                        ImGui.SameLine();
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes #9 (Asset browser assets go off screen if theres enough of them). 
Asset browser also now accepts more than one file being dragged onto it at once. 

(Side note, I wouldn't wish trying to figure out all these margin values upon anyone lol, ImGui has some really odd style names. Here's a handy guide image)
![image](https://github.com/naomiEve/VTubeTiny/assets/41798511/8b0e7199-4902-4a3a-8567-56209288a19a)
